### PR TITLE
docs: clarify delete auth requirement and .env-by-reference pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ focus on user-friendliness and security.
 - 🛡️ **Privacy-preserving rate-limiting** using Anonymous Rate-Limited Credentials (ARC)
   [(View Implementation)](lib/rate-limiting/)
 - 🤖 **AI-agent ready** - an official CLI ([`cli/main.ts`](cli/main.ts)) that encrypts/decrypts locally, so agents can
-  store and share API keys and other secrets without ever writing them to disk in plaintext. See
+  store and share API keys and other secrets without ever writing them to disk in plaintext. The CLI's `env` command
+  resolves VailNote links stored in `.env` files, so secrets can live by reference instead of plaintext. See
   [llms.txt](https://vailnote.com/llms.txt) (or the repo's [llms-full.txt](static/llms-full.txt)) for the full
   agent-facing documentation.
 
@@ -67,7 +68,8 @@ The system has been compromised and is marked with (!).
 2. The client asks the user for confirmation before viewing (and destroying) the note.
 3. If an auth key is present in the URL, the client uses it to decrypt the note. If a password is required, the client
    prompts for it and decrypts locally.
-4. The client never sends the password or auth key to the server—decryption always happens in the browser.
+4. The client never sends the raw password or auth key to the server—only a deterministic PBKDF2 hash of the password
+   (used for access control on fetch/delete); decryption always happens in the browser.
 5. After successful decryption, the client requests that the server delete the note.
 6. If decryption fails, the note remains on the server until a valid decryption attempt is made or it expires.
 

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -64,6 +64,8 @@ Request body:
 
 Request body: `{ "passwordHash": "<optional>" }`. Returns `200` `{ "message": "Note deleted successfully" }`.
 
+`passwordHash` is **required for password-protected notes**: the same access check as fetch applies, and without a matching hash the server responds `403 INVALID_PASSWORD_OR_AUTH_KEY` without deleting anything. It may only be omitted for notes created without a password, where possession of the link is the capability. The hash is a deterministic PBKDF2 verifier (never the raw password), so zero-knowledge is preserved: the server can gate deletion on the password without ever seeing plaintext or the auth key.
+
 ## Using VailNote from an AI agent (CLI)
 
 `cli/main.ts` is the official agent-facing client. It encrypts/decrypts locally, so an API key (or any secret) passed through VailNote is never stored on disk in plaintext and never sent to the server unencrypted. Secrets are better passed via stdin (create) and env vars (password) than as argv, which leaks through process listings and shell history.
@@ -147,6 +149,8 @@ set -a; source <(deno run --allow-net --allow-env --allow-read cli/main.ts env);
 ```
 
 Rules for this pattern: use `--manual-deletion` so the note survives repeated resolutions; add a password so the `.env` link alone is useless (then set `VAILNOTE_PASSWORD` when resolving); use `printf`/`echo -n` when creating so the stored value has no trailing newline (the `env` command strips trailing newlines on resolution anyway).
+
+**Important:** only tools that resolve the file (via `vailnote env`) ever see the real value. A process that reads `.env` directly gets the literal link as the value and fails auth — run the resolution *before* starting the consumer, e.g. `set -a; source <(vailnote env .env); set +a; my-agent`. Rotating the secret means creating a new note and swapping the link in `.env`; delete the old note (`vailnote delete`) so the retired secret doesn't linger. Manual-deletion notes persist until explicitly deleted or until the 180-day maximum expiry — schedule rotation accordingly.
 
 ## Security model
 


### PR DESCRIPTION
## What

Four documentation fixes found while dogfooding the CLI + API with Hermes:

1. **`llms-full.txt` — DELETE section** (`routes/api/notes/[id].ts`): `passwordHash` was documented as merely `<optional>`. In reality it is **required for password-protected notes** — the same `validateNoteAccess` check as fetch applies and missing/mismatched hashes get `403 INVALID_PASSWORD_OR_AUTH_KEY` without deleting. The docs now say so explicitly.

2. **`llms-full.txt` — `.env`-by-reference workflow**: added the critical caveat that only tools resolving via `vailnote env` ever see the real value — processes reading `.env` directly get the literal link. Also added rotation + expiry guidance (manual-deletion notes live until deleted or the 180-day cap).

3. **README — "Viewing the Note" step 4**: previously claimed the client "never sends the password". It never sends the *raw* password, but it does send a deterministic PBKDF2 hash for access control (per step 1 of the create flow). Clarified to keep the security model internally consistent.

4. **README — AI-agent ready bullet**: mentions the `env` command so the secret-by-reference pattern is discoverable from the README.

## Why

The DELETE wording is exactly what made me (as an agent user) suspect you could delete a password-protected note without the password — the docs contradicted the code. Zero-knowledge claim also held up: the hash is a PBKDF2 verifier, so the server gates delete on the password without ever seeing plaintext or the auth key.