### PR TITLE
fix: require link possession (auth key) to fetch/delete passwordless notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ focus on user-friendliness and security.
 - 🛡️ **Privacy-preserving rate-limiting** using Anonymous Rate-Limited Credentials (ARC)
   [(View Implementation)](lib/rate-limiting/)
 - 🤖 **AI-agent ready** - an official CLI ([`cli/main.ts`](cli/main.ts)) that encrypts/decrypts locally, so agents can
-  store and share API keys and other secrets without ever writing them to disk in plaintext. See
+  store and share API keys and other secrets without ever writing them to disk in plaintext. The CLI's `env` command
+  resolves VailNote links stored in `.env` files, so secrets can live by reference instead of plaintext. See
   [llms.txt](https://vailnote.com/llms.txt) (or the repo's [llms-full.txt](static/llms-full.txt)) for the full
   agent-facing documentation.
 
@@ -67,7 +68,8 @@ The system has been compromised and is marked with (!).
 2. The client asks the user for confirmation before viewing (and destroying) the note.
 3. If an auth key is present in the URL, the client uses it to decrypt the note. If a password is required, the client
    prompts for it and decrypts locally.
-4. The client never sends the password or auth key to the server—decryption always happens in the browser.
+4. The client never sends the raw password or auth key to the server—only a deterministic PBKDF2 hash of the password
+   (used for access control on fetch/delete); decryption always happens in the browser.
 5. After successful decryption, the client requests that the server delete the note.
 6. If decryption fails, the note remains on the server until a valid decryption attempt is made or it expires.
 

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -293,11 +293,13 @@ export async function createNote(content: string, opts: CliOptions): Promise<Cre
     }
 
     const { encryptedContent, passwordHash, authKey } = await prepareEncryption(content, opts.password);
+    const authKeyHash = await generateDeterministicClientHash(authKey);
 
     const data = await apiRequest(opts.origin, '/api/notes', 'POST', {
         content: encryptedContent.encrypted,
         iv: encryptedContent.iv,
         password: passwordHash,
+        authKeyHash,
         expiresIn: EXPIRY_API_VALUES[opts.expiresIn],
         manualDeletion: opts.manualDeletion,
     });
@@ -323,8 +325,9 @@ export async function readNote(link: string, opts: CliOptions): Promise<ReadResu
     const { id, authKey } = parseNoteLink(link);
     const password = opts.password;
     const passwordHash = password ? await generateDeterministicClientHash(password) : undefined;
+    const authKeyHash = authKey ? await generateDeterministicClientHash(authKey) : undefined;
 
-    const data = await apiRequest(opts.origin, `/api/notes/${id}`, 'POST', { passwordHash });
+    const data = await apiRequest(opts.origin, `/api/notes/${id}`, 'POST', { passwordHash, authKeyHash });
 
     if (typeof data.content !== 'string' || typeof data.iv !== 'string') {
         throw new CliError('Server response did not include note data');
@@ -360,12 +363,24 @@ export async function readNote(link: string, opts: CliOptions): Promise<ReadResu
 /**
  * Permanently delete a note. Required for manual-deletion notes; harmless
  * for auto-deleting notes that were already destroyed.
+ *
+ * The link's auth key (or the note password) is required: deletion is gated
+ * by the same possession check as reading, so an ID alone never deletes.
  */
 export async function deleteNote(link: string, opts: CliOptions): Promise<{ noteId: string }> {
-    const { id } = parseNoteLink(link);
-    const passwordHash = opts.password ? await generateDeterministicClientHash(opts.password) : undefined;
+    const { id, authKey } = parseNoteLink(link);
+    const password = opts.password;
+    const passwordHash = password ? await generateDeterministicClientHash(password) : undefined;
+    const authKeyHash = authKey ? await generateDeterministicClientHash(authKey) : undefined;
 
-    await apiRequest(opts.origin, `/api/notes/${id}`, 'DELETE', { passwordHash });
+    if (!authKey && !password) {
+        throw new CliError(
+            'Cannot delete this note: the link has no auth key and no password was provided. ' +
+                'Deletion requires possession of the full link (with #auth=...).',
+        );
+    }
+
+    await apiRequest(opts.origin, `/api/notes/${id}`, 'DELETE', { passwordHash, authKeyHash });
     return { noteId: id };
 }
 

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -5,7 +5,7 @@ import { generateDeterministicClientHash } from '../lib/hashing.ts';
 import { combineNoteSecrets, prepareEncryption } from '../lib/services/crypto-service.ts';
 import { NOTE_CONTENT_MAX_LENGTH } from '../lib/types.ts';
 
-export const CLI_VERSION = '1.0.0';
+export const CLI_VERSION = '1.0.1';
 export const DEFAULT_ORIGIN = 'https://vailnote.com';
 export const EXPIRY_OPTIONS = ['10m', '1h', '6h', '12h', '24h', '3d', '7d', '30d', '90d', '180d'] as const;
 export type ExpiryOption = typeof EXPIRY_OPTIONS[number];

--- a/islands/ViewNote.tsx
+++ b/islands/ViewNote.tsx
@@ -180,7 +180,7 @@ export default function ViewEncryptedNote({ noteId, manualDeletion, hasPassword,
 
         try {
             setDecryptionError(undefined);
-            const result = await NoteService.getNote(noteId, enteredPassword);
+            const result = await NoteService.getNote(noteId, getAuthKey() ?? undefined, enteredPassword);
 
             if (!result.success || !result.note) {
                 // The API now returns precise messages ("note not found", rate
@@ -217,7 +217,7 @@ export default function ViewEncryptedNote({ noteId, manualDeletion, hasPassword,
         }
 
         try {
-            await NoteService.deleteNote(noteId, password.current);
+            await NoteService.deleteNote(noteId, getAuthKey() ?? undefined, password.current);
             setMessage(MESSAGES.DELETE_SUCCESS);
             globalThis.location.href = '/';
         } catch (error) {

--- a/lib/services/note-service.ts
+++ b/lib/services/note-service.ts
@@ -12,11 +12,11 @@ export default class NoteService {
         return this.provider.create(data);
     }
 
-    static getNote(noteId: string, password?: string) {
-        return this.provider.get(noteId, password);
+    static getNote(noteId: string, authKey?: string, password?: string) {
+        return this.provider.get(noteId, authKey, password);
     }
 
-    static deleteNote(noteId: string, password?: string) {
-        return this.provider.delete(noteId, password);
+    static deleteNote(noteId: string, authKey?: string, password?: string) {
+        return this.provider.delete(noteId, authKey, password);
     }
 }

--- a/lib/services/storage/remote-storage.ts
+++ b/lib/services/storage/remote-storage.ts
@@ -12,6 +12,7 @@ export interface ApiNoteRequest {
     content: string;
     iv: string;
     password?: string;
+    authKeyHash?: string;
     expiresIn?: string;
     manualDeletion?: boolean;
 }
@@ -72,6 +73,7 @@ export default class RemoteStorage implements StorageProvider {
 
         try {
             const { encryptedContent, passwordHash, authKey } = await prepareEncryption(content, password);
+            const authKeyHash = await generateDeterministicClientHash(authKey);
 
             const response = await fetch('/api/notes', {
                 method: 'POST',
@@ -79,6 +81,7 @@ export default class RemoteStorage implements StorageProvider {
                 body: JSON.stringify({
                     content: encryptedContent.encrypted,
                     password: passwordHash,
+                    authKeyHash,
                     expiresIn,
                     manualDeletion,
                     iv: encryptedContent.iv,
@@ -100,14 +103,15 @@ export default class RemoteStorage implements StorageProvider {
         }
     }
 
-    async get(noteId: string, password?: string): Promise<GetEncryptedNoteResult> {
+    async get(noteId: string, authKey?: string, password?: string): Promise<GetEncryptedNoteResult> {
         try {
             const passwordHash = password ? await generateDeterministicClientHash(password) : undefined;
+            const authKeyHash = authKey ? await generateDeterministicClientHash(authKey) : undefined;
 
             const response = await fetch(`/api/notes/${noteId}`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ passwordHash }),
+                body: JSON.stringify({ passwordHash, authKeyHash }),
             });
 
             if (!response.ok) {
@@ -121,13 +125,15 @@ export default class RemoteStorage implements StorageProvider {
         }
     }
 
-    async delete(noteId: string, password: string): Promise<DeleteNoteResult> {
+    async delete(noteId: string, authKey?: string, password?: string): Promise<DeleteNoteResult> {
         try {
-            const passwordHash = await generateDeterministicClientHash(password);
+            const passwordHash = password ? await generateDeterministicClientHash(password) : undefined;
+            const authKeyHash = authKey ? await generateDeterministicClientHash(authKey) : undefined;
+
             const response = await fetch(`/api/notes/${noteId}`, {
                 method: 'DELETE',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ passwordHash }),
+                body: JSON.stringify({ passwordHash, authKeyHash }),
             });
 
             return response.ok ? { success: true } : { success: false, message: await parseErrorMessage(response) };

--- a/lib/services/storage/storage-provider.ts
+++ b/lib/services/storage/storage-provider.ts
@@ -29,6 +29,6 @@ export interface CreateNoteData {
 
 export interface StorageProvider {
     create(data: CreateNoteData): Promise<CreateNoteResult>;
-    get(noteId: string, password?: string): Promise<GetEncryptedNoteResult>;
-    delete(noteId: string, password?: string): Promise<DeleteNoteResult>;
+    get(noteId: string, authKey?: string, password?: string): Promise<GetEncryptedNoteResult>;
+    delete(noteId: string, authKey?: string, password?: string): Promise<DeleteNoteResult>;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -6,7 +6,8 @@ export interface Note {
     expiresIn: Date;
 
     // Optional fields for additional functionality
-    password?: string; // password hash for private notes
+    password?: string; // bcrypt'd deterministic hash of the password (password-protected notes)
+    authKeyHash?: string; // bcrypt'd deterministic hash of the auth key (passwordless notes with link-possession gate)
     manualDeletion?: boolean; // Flag for manual deletion
 }
 

--- a/lib/validation/note.ts
+++ b/lib/validation/note.ts
@@ -31,6 +31,12 @@ export const createNoteSchema = v.object({
             v.maxLength(NOTE_PASSWORD_MAX_LENGTH, 'Password is too long (max 256 characters)'),
         ),
     ), // Optional password with max length
+    authKeyHash: v.optional(
+        v.pipe(
+            v.string(),
+            v.maxLength(NOTE_PASSWORD_MAX_LENGTH, 'Auth key hash is too long (max 256 characters)'),
+        ),
+    ), // Optional deterministic hash of the auth key (enables link-possession gate)
     expiresIn: v.enum(EXPIRY_OPTIONS, 'Invalid expiration time. Please select a valid option.'),
     manualDeletion: v.union(
         [v.optional(v.enum(MANUAL_DELETION_OPTIONS)), v.boolean()],

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vailnote-cli",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Official VailNote CLI - create, read, and delete end-to-end encrypted notes. Content is encrypted and decrypted locally; the server only ever stores ciphertext.",
     "license": "MIT",
     "type": "module",

--- a/routes/api/notes.ts
+++ b/routes/api/notes.ts
@@ -32,32 +32,38 @@ export const handler = {
                 return jsonError(400, 'Invalid request body', 'INVALID_REQUEST_BODY');
             }
 
-            const { content, iv, password, expiresIn, manualDeletion } = body as {
+            const { content, iv, password, authKeyHash, expiresIn, manualDeletion } = body as {
                 content: string;
                 iv: string;
                 password?: string;
+                authKeyHash?: string;
                 expiresIn: string;
                 manualDeletion?: boolean;
             };
 
             // Validate input using valibot
             try {
-                v.parse(createNoteSchema, { content, iv, password, expiresIn, manualDeletion });
+                v.parse(createNoteSchema, { content, iv, password, authKeyHash, expiresIn, manualDeletion });
             } catch {
                 return jsonError(400, 'Invalid request data', 'INVALID_DATA');
             }
 
             const noteId = await noteDatabase.generateNoteId();
             const hasPassword = password && password.trim() !== '';
+            const hasAuthKeyHash = authKeyHash && authKeyHash.trim() !== '';
 
             // if password is provided, hash it with bcrypt (password should be PBKDF2 hashed on client before sending)
             const passwordHash = hasPassword ? await generateHash(password) : undefined;
+            // if an auth-key verifier is provided, hash it with bcrypt for storage.
+            // The server stores only one-way verifiers - it never sees the auth key itself.
+            const storedAuthKeyHash = hasAuthKeyHash ? await generateHash(authKeyHash) : undefined;
 
             // check if content is encrypted
             const result: Note = {
                 id: noteId,
                 content, // content should be encrypted before sending to this endpoint
                 password: passwordHash, // password is PBKDF2 non-deterministic hashed on client, then bcrypt hashed on server for secure storage
+                authKeyHash: storedAuthKeyHash, // deterministic client hash of the auth key, bcrypt hashed on server
                 iv: iv,
                 expiresIn: formatExpiration(expiresIn),
                 manualDeletion: manualDeletion,

--- a/routes/api/notes/[id].ts
+++ b/routes/api/notes/[id].ts
@@ -5,7 +5,11 @@ import { State } from '../../../lib/types/common.ts';
 import { noteDatabase } from '../../../main.ts';
 import { jsonError, jsonResponse } from '../../../lib/http.ts';
 
-async function validateNoteAccess(id: string, passwordHash?: string): Promise<{ note: Note | null; error?: Response }> {
+async function validateNoteAccess(
+    id: string,
+    passwordHash?: string,
+    authKeyHash?: string,
+): Promise<{ note: Note | null; error?: Response }> {
     const note = await noteDatabase.getNoteById(id);
 
     // if the note does not exist, return a 404 error
@@ -26,7 +30,19 @@ async function validateNoteAccess(id: string, passwordHash?: string): Promise<{ 
                 error: jsonError(403, 'Invalid password or auth key', 'INVALID_PASSWORD_OR_AUTH_KEY'),
             };
         }
+    } else if (note.authKeyHash) {
+        // Passwordless notes created with an auth-key verifier: possession of
+        // the link (note ID + auth key) is required to fetch or delete.
+        // Do not fail open when the caller omits the hash.
+        if (!authKeyHash || !(await compareHash(authKeyHash, note.authKeyHash))) {
+            return {
+                note: null,
+                error: jsonError(403, 'Invalid password or auth key', 'INVALID_PASSWORD_OR_AUTH_KEY'),
+            };
+        }
     }
+    // Legacy notes (created without any verifier) remain addressable by ID
+    // alone until they expire - the server never learned a verifier for them.
 
     return { note };
 }
@@ -42,14 +58,16 @@ export const handler = async (ctx: Context<State>): Promise<Response> => {
     }
 
     let passwordHash: string | undefined;
+    let authKeyHash: string | undefined;
     try {
         const body = await ctx.req.json();
         passwordHash = body?.passwordHash;
+        authKeyHash = body?.authKeyHash;
     } catch {
         return jsonError(400, 'Invalid request body', 'INVALID_REQUEST_BODY');
     }
 
-    const { note, error } = await validateNoteAccess(id, passwordHash);
+    const { note, error } = await validateNoteAccess(id, passwordHash, authKeyHash);
 
     if (error) return error;
     if (!note) return jsonError(404, 'Note not found', 'NOTE_NOT_FOUND');

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -64,6 +64,8 @@ Request body:
 
 Request body: `{ "passwordHash": "<optional>" }`. Returns `200` `{ "message": "Note deleted successfully" }`.
 
+`passwordHash` is **required for password-protected notes**: the same access check as fetch applies, and without a matching hash the server responds `403 INVALID_PASSWORD_OR_AUTH_KEY` without deleting anything. It may only be omitted for notes created without a password, where possession of the link is the capability. The hash is a deterministic PBKDF2 verifier (never the raw password), so zero-knowledge is preserved: the server can gate deletion on the password without ever seeing plaintext or the auth key.
+
 ## Using VailNote from an AI agent (CLI)
 
 `cli/main.ts` is the official agent-facing client. It encrypts/decrypts locally, so an API key (or any secret) passed through VailNote is never stored on disk in plaintext and never sent to the server unencrypted. Secrets are better passed via stdin (create) and env vars (password) than as argv, which leaks through process listings and shell history.
@@ -147,6 +149,8 @@ set -a; source <(deno run --allow-net --allow-env --allow-read cli/main.ts env);
 ```
 
 Rules for this pattern: use `--manual-deletion` so the note survives repeated resolutions; add a password so the `.env` link alone is useless (then set `VAILNOTE_PASSWORD` when resolving); use `printf`/`echo -n` when creating so the stored value has no trailing newline (the `env` command strips trailing newlines on resolution anyway).
+
+**Important:** only tools that resolve the file (via `vailnote env`) ever see the real value. A process that reads `.env` directly gets the literal link as the value and fails auth — run the resolution *before* starting the consumer, e.g. `set -a; source <(vailnote env .env); set +a; my-agent`. Rotating the secret means creating a new note and swapping the link in `.env`; delete the old note (`vailnote delete`) so the retired secret doesn't linger. Manual-deletion notes persist until explicitly deleted or until the 180-day maximum expiry — schedule rotation accordingly.
 
 ## Security model
 

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -35,6 +35,7 @@ Request body:
   "content": "<base64 AES-GCM ciphertext>",
   "iv": "<base64 12-byte IV>",
   "password": "<optional: deterministic PBKDF2 hash of the password>",
+  "authKeyHash": "<optional: deterministic PBKDF2 hash of the auth key>",
   "expiresIn": "24 hours",
   "manualDeletion": false
 }
@@ -46,25 +47,32 @@ Response `201`:
 { "message": "Note saved successfully!", "noteId": "..." }
 ```
 
-Important: the content must be encrypted before this request. The server rejects nothing that lets it see plaintext - encryption is the client's job. Plaintext may be at most 46 KB, and `expiresIn` must be one of the human-readable values listed above (short codes like `24h` are rejected).
+Important: the content must be encrypted before this request. The server rejects nothing that lets it see plaintext - encryption is the client's job. Plaintext may be at most 46 KB, and `expiresIn` must be one of the human-readable values listed above (short codes like `24h` are rejected). `authKeyHash` is the deterministic PBKDF2 hash of the link's auth key; when provided, the server stores a bcrypt verifier and requires possession of the full link (ID + auth key) to fetch or delete the note. Notes created without it remain addressable by ID alone (legacy behavior).
 
 ### Fetch a note - `POST /api/notes/:id`
 
 Request body:
 
 ```json
-{ "passwordHash": "<optional: deterministic PBKDF2 hash of the password>" }
+{
+  "passwordHash": "<optional: deterministic PBKDF2 hash of the password>",
+  "authKeyHash": "<optional: deterministic PBKDF2 hash of the auth key>"
+}
 ```
 
 - `200`: `{ "id", "content", "iv", "expiresIn", "password?", "manualDeletion" }` (ciphertext; auto-delete notes are destroyed after this call).
-- `403`: invalid/missing password for a password-protected note.
+- `403`: invalid/missing password for a password-protected note, or invalid/missing auth-key verifier for a passwordless note created with `authKeyHash`.
 - `404`: note not found (already destroyed or expired).
 
 ### Delete a note - `DELETE /api/notes/:id`
 
-Request body: `{ "passwordHash": "<optional>" }`. Returns `200` `{ "message": "Note deleted successfully" }`.
+Request body: `{ "passwordHash": "<optional>", "authKeyHash": "<optional>" }`. Returns `200` `{ "message": "Note deleted successfully" }`.
 
-`passwordHash` is **required for password-protected notes**: the same access check as fetch applies, and without a matching hash the server responds `403 INVALID_PASSWORD_OR_AUTH_KEY` without deleting anything. It may only be omitted for notes created without a password, where possession of the link is the capability. The hash is a deterministic PBKDF2 verifier (never the raw password), so zero-knowledge is preserved: the server can gate deletion on the password without ever seeing plaintext or the auth key.
+`passwordHash` is **required for password-protected notes**: the same access check as fetch applies, and without a matching hash the server responds `403 INVALID_PASSWORD_OR_AUTH_KEY` without deleting anything. It may only be omitted for notes created without a password, where possession of the link is the capability.
+
+`authKeyHash` is **required for passwordless notes created with `authKeyHash`**: an ID alone is never enough to delete - the caller must prove possession of the full link (ID + auth key). Notes created without a verifier (legacy) remain deletable by ID alone until they expire.
+
+The hashes are deterministic PBKDF2 verifiers (never the raw password or auth key), so zero-knowledge is preserved: the server can gate fetch and deletion on possession of the link without ever seeing plaintext or the auth key itself.
 
 ## Using VailNote from an AI agent (CLI)
 

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -57,6 +57,7 @@ Deno.test({
         const handler = new App<State>()
             .post('/api/notes', async (ctx) => await notesHandler.POST(ctx))
             .post('/api/notes/:id', async (ctx) => await notesIdHandler(ctx))
+            .delete('/api/notes/:id', async (ctx) => await notesIdHandler(ctx))
             .handler();
 
         let apiNoteId: string;
@@ -131,6 +132,71 @@ Deno.test({
             );
 
             assertEquals(authorizedResponse.status, 200);
+        });
+
+        await t.step('should require authKeyHash for passwordless note fetch and delete', async () => {
+            const authKey = 'testAuthKey123456';
+            const authKeyHash = await generateDeterministicClientHash(authKey);
+            const encryptedContent = await encryptNoteContent(testData.content, authKey);
+
+            const createResponse = await handler(
+                new Request(`http://localhost/api/notes`, {
+                    method: 'POST',
+                    body: JSON.stringify({
+                        content: encryptedContent.encrypted,
+                        iv: encryptedContent.iv,
+                        authKeyHash,
+                        expiresIn: testData.expiresIn,
+                        manualDeletion: true,
+                    }),
+                    headers: { 'Content-Type': 'application/json' },
+                }),
+            );
+
+            assertEquals(createResponse.status, 201);
+            const createData = await createResponse.json();
+            const gatedNoteId = createData.noteId;
+            assertExists(gatedNoteId, 'Note ID should be present in API response');
+
+            // Fetch without the auth-key verifier must be rejected.
+            const unauthorizedFetch = await handler(
+                new Request(`http://localhost/api/notes/${gatedNoteId}`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({}),
+                }),
+            );
+            assertEquals(unauthorizedFetch.status, 403);
+
+            // Fetch with the correct verifier succeeds.
+            const authorizedFetch = await handler(
+                new Request(`http://localhost/api/notes/${gatedNoteId}`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ authKeyHash }),
+                }),
+            );
+            assertEquals(authorizedFetch.status, 200);
+
+            // Delete without the auth-key verifier must be rejected.
+            const unauthorizedDelete = await handler(
+                new Request(`http://localhost/api/notes/${gatedNoteId}`, {
+                    method: 'DELETE',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({}),
+                }),
+            );
+            assertEquals(unauthorizedDelete.status, 403);
+
+            // Delete with the correct verifier succeeds.
+            const authorizedDelete = await handler(
+                new Request(`http://localhost/api/notes/${gatedNoteId}`, {
+                    method: 'DELETE',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ authKeyHash }),
+                }),
+            );
+            assertEquals(authorizedDelete.status, 200);
         });
 
         await t.step('should retrieve note by ID', async () => {


### PR DESCRIPTION
## The bug

`vailnote delete https://vailnote.com/<id>` (no `#auth=` fragment) deleted the note. The server never stored any verifier for the auth key — for passwordless notes, possession of the **note ID alone** was enough to fetch (which destroys auto-delete notes) or delete.

## Root cause

Zero-knowledge means the server never sees the auth key. But it also means it can't check it — so the ID (12 hex chars, leaks from logs/proxies/history) became the de-facto capability for passwordless notes. The `#auth=` fragment was verified by *nothing* on the server.

## The fix (zero-knowledge preserved)

Mirror the existing password-verifier pattern for the auth key:

- **Create**: client sends `authKeyHash` = deterministic PBKDF2 hash of the auth key → server stores `bcrypt(authKeyHash)` (one-way; same as the password verifier)
- **Fetch/Delete**: passwordless notes with a stored verifier now require a matching `authKeyHash` → `403 INVALID_PASSWORD_OR_AUTH_KEY` otherwise; ID alone is never enough
- **Legacy**: notes created without a verifier keep ID-addressable behavior until they expire — no breakage for existing notes or old clients
- **CLI**: sends `authKeyHash` on create/read/delete; `vailnote delete` now refuses a link without `#auth=` (or a password) locally
- **Web client**: `NoteService`/`RemoteStorage` thread the auth key from the link fragment and send the verifier on create/fetch/delete

## Security notes

- Server stores only one-way verifiers (bcrypt'd PBKDF2) — it still cannot produce plaintext or recover the auth key
- Same attack surface as any password-verifier scheme: offline guessing only matters with a compromised server + weak auth key entropy; mitigated by PBKDF2 600k + bcrypt 12 rounds
- Rate limiting (15 mutating req/min) already bounds online guessing

## Verification

- New test step: create with `authKeyHash` → fetch/delete without verifier = 403, with verifier = 200 (manual-deletion note so fetch doesn't destroy it)
- Full suite: **28 passed (44 steps), 0 failed**
- `deno check main.ts cli/main.ts` clean